### PR TITLE
Switch from whitelist to blacklisting and prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Automatically switches A2DP/HSP/HFP when a microphone is needed in Linux and pul
  - `pactl`: The pactl executable should be available.
  - `ruby`: `>= 2.0.0` should work. Tested with `2.7.2`
  - `pipewire-pulse`: **Optional** if you are using pipewire.
+ - `zenity`: To ask before switching.
 
 ## Installation
 
@@ -23,9 +24,9 @@ Or you can just clone and run the `bluez_pa_auto_switcher.rb` file manually.
 
 ## Configuration
 
-You can edit the `~/.config/bluez_pa_auto_switcher/config.yaml` file to change the configuration.
+You can edit the `~/.config/bluez_pa_auto_switcher/config.yaml` file to change the configuration. For example you can unblock an app which you have blocked by removing it from the config file.
 
- - `validClients`: A list of application names to support auto switching for.
+ - `invalidClients`: A list of application names to disable the auto switching prompt for. Apps will be added to this list when you choose `Never For APP` from the prompt automatically.
 
 After changing configuration you will need to restart the service using systemd.
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,4 @@
-validClients:
-  - Chromium
-  - Firefox
-  - Chromium
-  - Skype
-  - ZOOM VoiceEngine
-  - WEBRTC VoiceEngine
-  - Google Chrome
-  - Microsoft Teams - Preview
+---
+invalidClients: []
+inputCardProfile: headset_head_unit
+normalCardProfile: a2dp_sink

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,15 @@ if [ $? != 0 ]; then
   exit 1
 fi
 
+which zenity >> /dev/null
+
+if [ $? != 0 ]; then
+  echo ""
+  echo -e "\033[0;31mZenity not found!\033[0m Please install zenity for your distro."
+  echo "For example: sudo apt-get install -y zenity"
+  exit 1
+fi
+
 if [ "$USER" == "root" ]; then
   echo ""
   echo -e "\033[0;31mRunning as root detected!\033[0m If you are not logged-in with root user this will NOT work."


### PR DESCRIPTION
Instead of having a whitelist for different applications it is better to have a blacklist and prompt every time a non blacklisted application wants to have an input sink.

Also ability to change the profile names in configuration is added.

## Checklist

 - [ ] Blacklisting adds the item in the `config.yaml` file.
 - [ ] Switching prompt shows and works.
 - [ ] Switch back notification is showing.